### PR TITLE
agrega grupos de seguridad para ALB, app, DB y bastión

### DIFF
--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,127 @@
+# create security group for the application load balancer
+resource "aws_security_group" "alb_security_group" {
+  name        = "${var.project_name}-${var.environment}-alb-sg"
+  description = "enable http/https access on port 80/443"
+  vpc_id      = aws_vpc.main_vpc.id
+
+  ingress {
+    description      = "http access"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description      = "https access"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = -1
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags   = {
+    Name = "${var.project_name}-${var.environment}-alb-sg"
+  }
+}
+
+# create security group for the bastion host aka jump box
+resource "aws_security_group" "bastion_security_group" {
+  name        = "${var.project_name}-${var.environment}-bastion-sg"
+  description = "enable ssh access on port 22"
+  vpc_id      = aws_vpc.main_vpc.id
+
+  ingress {
+    description      = "ssh access"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = [var.ssh_location]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = -1
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags   = {
+    Name = "${var.project_name}-${var.environment}-bastion-sg"
+  }
+}
+
+# create security group for the app server
+resource "aws_security_group" "app_server_security_group" {
+  name        = "${var.project_name}-${var.environment}-app-server-sg"
+  description = "enable http/https access on port 80/443 via alb sg"
+  vpc_id      = aws_vpc.main_vpc.id
+
+  ingress {
+    description      = "http access"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb_security_group.id]
+  }
+
+  ingress {
+    description      = "https access"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb_security_group.id]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = -1
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags   = {
+    Name = "${var.project_name}-${var.environment}-app-server-sg"
+  }
+}
+
+# create security group for the database
+resource "aws_security_group" "database_security_group" {
+  name        = "${var.project_name}-${var.environment}-database-sg"
+  description = "enable mysql/aurora access on port 3306"
+  vpc_id      = aws_vpc.main_vpc.id
+
+  ingress {
+    description      = "mysql/aurora access"
+    from_port        = 3306
+    to_port          = 3306
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.app_server_security_group.id]
+  }
+
+  ingress {
+    description      = "custom access"
+    from_port        = 3306
+    to_port          = 3306
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.bastion_security_group.id]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = -1
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags   = {
+    Name = "${var.project_name}-${var.environment}-database-sg"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,11 @@ variable "vpc_aws_az-2" {
   default = "us-east-1b"
 }
 
+
+variable "ssh_location" {
+  type = string
+}
+
 /*
   output "ec2-id" {
     value = aws_instance.ac1-instance.id


### PR DESCRIPTION
- Crea Security Group para el Application Load Balancer con acceso HTTP/HTTPS público.
- Define SG para bastion host con acceso SSH restringido por IP (var.ssh_location).
- Crea SG para servidores de aplicación, permitiendo tráfico HTTP/HTTPS solo desde el ALB.
- Crea SG para base de datos, permitiendo conexiones desde servidores de app y bastión en puerto 3306.
- Egress abierto en todos los SGs.